### PR TITLE
Fix/errors

### DIFF
--- a/minishell/include/minishell.h
+++ b/minishell/include/minishell.h
@@ -91,6 +91,7 @@ typedef struct s_lexer
 	name_infile -> nombre infile
 	name_outfile -> nombre outile
 	syntax_error -> error que devuelve
+	syntax_error -> error que devuelve si falla las redirreciones
 */
 typedef struct s_parcer
 {
@@ -102,6 +103,7 @@ typedef struct s_parcer
 	char			*name_infile;
 	char			*name_outfile;
 	int				syntax_error;
+	int				redir_error;
 	struct s_parcer	*next;
 }					t_parcer;
 

--- a/minishell/src/execute/procces_execve_aux.c
+++ b/minishell/src/execute/procces_execve_aux.c
@@ -14,6 +14,15 @@
 
 void	fd_redirect(t_parcer **list, int *i, t_mini *mini, int pipes[][2])
 {
+    if ((*list)->redir_error || (*list)->syntax_error)
+    {
+        if (*i > 0)
+            close(pipes[*i - 1][0]);
+        if (*i < mini->num_cmd - 1)
+            close(pipes[*i][1]);
+
+        exit(1);
+    }
 	if ((*list)->infile != -1)
 		dup2((*list)->infile, STDIN_FILENO);
 	else if (*i > 0)
@@ -36,7 +45,8 @@ void	exec_cmd(t_parcer *list, char **envp)
 	if (!cmd_path)
 	{
 		free_split(exec_cmd);
-		exit(EXIT_FAILURE);
+		printf("%s: command not found\n",list->cmd_args);
+		exit(127);
 	}
 	if (execve(cmd_path, exec_cmd, envp) == -1 && list->cmd_args)
 	{

--- a/minishell/src/execute/proccess_execve.c
+++ b/minishell/src/execute/proccess_execve.c
@@ -74,6 +74,20 @@ void	init_proccess(t_mini *mini, pid_t *pids, int pipes[][2], t_shell *envp)
 	i = 0;
 	while (i < mini->num_cmd)
 	{
+		if (list->syntax_error || list->redir_error)
+    	{
+        	envp->last_status = 1;
+        	if (i > 0)
+            	close(pipes[i - 1][0]);
+
+        	if (i < mini->num_cmd - 1)
+            	close(pipes[i][1]);
+
+        	pids[i] = -1;
+        	list = list->next;
+        	i++;
+        	continue;
+    	}
 		pids[i] = fork();
 		if (pids[i] == 0)
 			child_exec(list, mini, pipes, envp);
@@ -92,6 +106,11 @@ int	wait_childrens(pid_t *pids, int num_cmd)
 	last_status = 0;
 	while (i < num_cmd)
 	{
+		if (pids[i] == -1)
+		{
+			i++;
+			continue;
+		}
 		waitpid(pids[i], &status, 0);
 		if (WIFEXITED(status))
 			last_status = WEXITSTATUS(status);

--- a/minishell/src/parser/check_redirection.c
+++ b/minishell/src/parser/check_redirection.c
@@ -18,6 +18,12 @@ t_lexer	*handle_infile(t_lexer *aux, t_parcer *new_parcer)
 		return (NULL);
 	new_parcer->name_infile = ft_strdup(aux->inf);
 	new_parcer->infile = open(aux->inf, O_RDONLY);
+	if (new_parcer->infile == -1)
+	{
+		printf("No such file or directory\n");
+		new_parcer->syntax_error = 1;
+		// hay que poner el last_status en -1
+	}
 	return (aux->next);
 }
 

--- a/minishell/src/parser/check_redirection.c
+++ b/minishell/src/parser/check_redirection.c
@@ -22,7 +22,8 @@ t_lexer	*handle_infile(t_lexer *aux, t_parcer *new_parcer)
 	{
 		printf("No such file or directory\n");
 		new_parcer->syntax_error = 1;
-		// hay que poner el last_status en -1
+		new_parcer->redir_error = 1;
+		return (aux->next);
 	}
 	return (aux->next);
 }
@@ -31,13 +32,19 @@ t_lexer	*handle_outfile(t_lexer *aux, t_parcer *new_parcer)
 {
 	int	appened;
 
-	if (!aux || !aux->next || aux->next->token != T_OUTFILE)
-	{
-		if (!aux)
+	if (!aux)
 			return (NULL);
-		return (aux->next);
+	if (new_parcer->redir_error)
+	{
+		if (aux->next == NULL)
+			return (NULL);
+		return (aux->next->next);
 	}
+	if (!aux || !aux->next || aux->next->token != T_OUTFILE)
+		return (aux->next);
 	appened = (ft_strncmp(aux->inf, ">>", 3) == 0);
 	new_parcer->outfile = open_outfile(aux->next->inf, appened);
+	if (new_parcer->outfile == -1)
+		printf("No such file or directory\n");
 	return (aux->next->next);
 }

--- a/minishell/src/parser/parcer.c
+++ b/minishell/src/parser/parcer.c
@@ -28,6 +28,7 @@ static t_parcer	*mem_parcer(void)
 	parcer->name_infile = NULL;
 	parcer->name_outfile = NULL;
 	parcer->syntax_error = 0;
+	parcer->redir_error = 0;
 	return (parcer);
 }
 
@@ -40,6 +41,13 @@ static void	process_tokens(t_lexer **aux, t_parcer *new_parcer)
 {
 	while (*aux && (*aux)->token != T_PIPE)
 	{
+		 if (new_parcer->redir_error || new_parcer->syntax_error)
+        {
+            while (*aux && (*aux)->token != T_PIPE)
+                *aux = (*aux)->next;
+            return;
+        }
+
 		if (*aux && (*aux)->token == T_REDIR_IN)
 			if ((*aux)->next && (*aux)->next->token == T_INFILE)
 			*aux = (*aux)->next;

--- a/minishell/src/parser/parcer.c
+++ b/minishell/src/parser/parcer.c
@@ -33,7 +33,7 @@ static t_parcer	*mem_parcer(void)
 
 static void	print_error_syntax(void)
 {
-	printf("error sintáctico cerca del elemento inesperado `newline'\n");
+	printf("syntax error near unexpected token `newline'\n");
 }
 
 static void	process_tokens(t_lexer **aux, t_parcer *new_parcer)
@@ -41,7 +41,15 @@ static void	process_tokens(t_lexer **aux, t_parcer *new_parcer)
 	while (*aux && (*aux)->token != T_PIPE)
 	{
 		if (*aux && (*aux)->token == T_REDIR_IN)
+			if ((*aux)->next && (*aux)->next->token == T_INFILE)
 			*aux = (*aux)->next;
+			 else
+    		{
+        		print_error_syntax();
+        		*aux = NULL;
+        		new_parcer->syntax_error = 1;
+        		return ;
+    		}
 		else if (*aux && (*aux)->token == T_INFILE)
 			*aux = handle_infile((*aux), new_parcer);
 		else if ((*aux)->token == T_HEREDOC)


### PR DESCRIPTION
This pull request improves error handling for command redirections in the minishell project. The main changes include adding a dedicated `redir_error` field to the `t_parcer` struct, updating logic to handle redirection failures gracefully, and ensuring that processes and error messages are managed correctly when redirection errors occur.

**Redirection Error Handling Improvements**

* Added a new `int redir_error` field to the `t_parcer` struct to specifically track redirection errors separately from general syntax errors. (`minishell/include/minishell.h`)
* Updated the parser and redirection handler functions to set `redir_error` when file operations fail, print appropriate error messages, and skip further token processing for commands with redirection errors. (`minishell/src/parser/parcer.c`, `minishell/src/parser/check_redirection.c`) [[1]](diffhunk://#diff-37b21b63fdd5546fe16bb1f66e7ccb4fa52b7ad6da01846008fa0f566c8febfdR31-R60) [[2]](diffhunk://#diff-3b472afa97cf07e9aa8b516c356a573e935f4f63c06523a6740a95291bbec592R21-R48)

**Execution Flow Adjustments**

* Modified process creation logic to skip forking child processes for commands with either `syntax_error` or `redir_error`, and set their PID to `-1` for proper tracking. (`minishell/src/execute/proccess_execve.c`)
* Updated the child process execution and file descriptor redirection logic to immediately exit if a redirection or syntax error is detected. (`minishell/src/execute/procces_execve_aux.c`)

**Error Reporting and Status Management**

* Changed error reporting to print more informative messages when commands are not found and when files for redirection are missing, and adjusted exit codes to match shell conventions. (`minishell/src/execute/procces_execve_aux.c`, `minishell/src/parser/check_redirection.c`) [[1]](diffhunk://#diff-3c87f6e7094360dc4f273fb12e009e1c136a55f57a0c27ce4b90a4f1a4032a3eL39-R49) [[2]](diffhunk://#diff-3b472afa97cf07e9aa8b516c356a573e935f4f63c06523a6740a95291bbec592R21-R48)
* Updated the process waiting logic to skip waiting for commands that were not executed due to errors, ensuring the shell's last status reflects only valid child processes. (`minishell/src/execute/proccess_execve.c`)